### PR TITLE
0.1.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+test/
+ld_badger/
+.idea/

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
-- unit tests?
+- unit tests for streams
 - client implementations to test more RPCs
 - client CRUD implementation example

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,4 @@
+- make docker work
 - benchmarks
 - client implementations to test more RPCs
 - client CRUD implementation example

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,3 @@
-- unit tests for streams
+- benchmarks
 - client implementations to test more RPCs
 - client CRUD implementation example

--- a/impl/delete.go
+++ b/impl/delete.go
@@ -53,7 +53,7 @@ func (l ldService) DeleteMany(server pb.Ld_DeleteManyServer) error {
 			var value []byte
 			value, err := readSingleFromKey(txn, k)
 			if err == badger.ErrKeyNotFound {
-				out <- &pb.KeyValue{}
+				out <- nil
 				continue
 			}
 			if err != nil {
@@ -119,7 +119,7 @@ func (l ldService) DeleteRange(keyRange *pb.KeyRange, server pb.Ld_DeleteRangeSe
 		for key := range chKeyMatches {
 			value, err := readSingleFromKey(txn, key)
 			if err == badger.ErrKeyNotFound {
-				out <- &pb.KeyValue{}
+				out <- nil
 				err = nil
 			}
 			if err != nil {
@@ -127,7 +127,7 @@ func (l ldService) DeleteRange(keyRange *pb.KeyRange, server pb.Ld_DeleteRangeSe
 			}
 			err = txn.Delete([]byte(key.Key))
 			if err != nil {
-				out <- &pb.KeyValue{}
+				out <- nil
 				log.Info("error when deleting record", err)
 				continue
 			}

--- a/impl/get.go
+++ b/impl/get.go
@@ -17,14 +17,7 @@ func (l ldService) Get(_ context.Context, key *pb.Key) (*pb.KeyValue, error) {
 		value, err = readSingleFromKey(txn, key)
 		return
 	})
-	if err == badger.ErrKeyNotFound {
-		return &pb.KeyValue{}, nil
-	}
-	if err != nil {
-		log.Warnf("error while fetching data from database: %v", err)
-		return nil, err
-	}
-	return &pb.KeyValue{Key: key.Key, Value: value}, nil
+	return decideOutcome(err, key.Key, value)
 }
 
 // GetMany implements RPC stream method of the same name from LdServer

--- a/impl/get_test.go
+++ b/impl/get_test.go
@@ -1,0 +1,111 @@
+package impl
+
+import (
+	"bytes"
+	"github.com/MikkelHJuul/ld/proto"
+	"testing"
+)
+
+func Test_ldService_GetMany(t *testing.T) {
+	l := NewServer("", true)
+	err := l.SetMany(NewTestServer(oneThroughHundred()))
+	if err != nil {
+		t.Errorf("could not initiate test database")
+	}
+	tests := []struct {
+		name    string
+		server  *testBidiKeyServer
+		results []*proto.KeyValue
+	}{
+		{
+			name: "get some valid keys",
+			server: NewTestKeyServer([]*proto.Key{
+				{Key: "04"},
+				{Key: "40"},
+				{Key: "99"},
+				{Key: "00"},
+				{Key: "22"},
+			}),
+			results: []*proto.KeyValue{
+				{Key: "04", Value: []byte("04")},
+				{Key: "40", Value: []byte("40")},
+				{Key: "99", Value: []byte("99")},
+				{Key: "00", Value: []byte("00")},
+				{Key: "22", Value: []byte("22")},
+			},
+		},
+		{
+			name: "get invalid keys",
+			server: NewTestKeyServer([]*proto.Key{
+				{Key: "99"},
+				{Key: "00"},
+				{Key: "100"},
+				{Key: "a"},
+			}),
+			results: []*proto.KeyValue{
+				{Key: "99", Value: []byte("99")},
+				{Key: "00", Value: []byte("00")},
+				nil,
+				nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := l.GetMany(tt.server); err != nil {
+				t.Errorf("GetMany() error = %v", err)
+			}
+			if len(tt.server.receive) != len(tt.results) {
+				t.Errorf("not the same amount of results, %d =|= %d", len(tt.server.receive), len(tt.results))
+			}
+			numNils := 0
+			for _, aVal := range tt.server.receive {
+				if aVal == nil {
+					numNils++
+					continue
+				}
+				isThere := false
+				for _, res := range tt.results {
+					if aVal.Key == res.Key && bytes.Equal(aVal.Value, res.Value) {
+						isThere = true
+						break
+					}
+				}
+				if !isThere {
+					t.Errorf("results are not like! %v != %v", tt.server.receive, tt.results)
+				}
+			}
+			for _, res := range tt.results {
+				if res == nil {
+					numNils--
+				}
+			}
+			if numNils != 0 {
+				t.Errorf("incorrect numbers of empty messages as expected")
+			}
+		})
+	}
+}
+
+func Test_ldService_GetRange(t *testing.T) {
+	l := NewServer("", true)
+	err := l.SetMany(NewTestServer(oneThroughHundred()))
+	if err != nil {
+		t.Errorf("could not initiate test database")
+	}
+	tests := []struct {
+		name     string
+		server   *testBidiServer
+		keyRange *proto.KeyRange
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := l.GetRange(tt.keyRange, tt.server); err != nil {
+				t.Errorf("GetRange() error = %v", err)
+			}
+
+		})
+	}
+}

--- a/impl/iterator.go
+++ b/impl/iterator.go
@@ -35,6 +35,34 @@ type badgerFromToIterator struct {
 	to []byte
 }
 
+type badgerFromIterator struct {
+	badgerPrefixIterator
+}
+
+type badgerToIterator struct {
+	badgerFromToIterator
+}
+
+// a badgerPrefixToIterator is simply a FromToIterator,
+//while badgerPrefixFromIterator is slightly faster than
+//a badgerFromToIterator iterator, and the logic wouldn't work anyway
+type badgerPrefixFromIterator struct {
+	badgerPrefixIterator
+	from []byte
+}
+
+func (b badgerPrefixFromIterator) Rewind() {
+	b.Seek(b.from)
+}
+
+func (b *badgerToIterator) Rewind() {
+	b.Iterator.Rewind()
+}
+
+func (b *badgerFromIterator) Valid() bool {
+	return b.Iterator.Valid()
+}
+
 func (b *badgerPrefixIterator) Rewind() {
 	b.Seek(b.prefix)
 }
@@ -44,29 +72,65 @@ func (b *badgerPrefixIterator) Valid() bool {
 }
 
 func (b *badgerFromToIterator) Valid() bool {
-	return b.Iterator.Valid() && 1 > bytes.Compare(b.Item().Key(), b.to)
+	return b.Iterator.Valid() && keyLtEq(b.Item().Key(), b.to)
+}
+
+func keyLtEq(key, upperBound []byte) bool {
+	return 1 > bytes.Compare(key, upperBound)
 }
 
 // KeyRangeIterator returns an Iterator interface implementation, that wraps the badger.Iterator
 // in order to simplify iterating with from-to and/or prefix.
 func KeyRangeIterator(it *badger.Iterator, prefix, from, to string) Iterator {
-	if prefix+from+to != "" {
-		f, t := prefix, prefix
-		if from != "" && prefix < from {
-			f = from
+	switch {
+	case prefix+from+to == "":
+		return it
+	case prefix != "" && from+to == "":
+		return &badgerPrefixIterator{*it, []byte(prefix)}
+	case to != "" && prefix+from == "":
+		return &badgerToIterator{badgerFromToIterator{badgerPrefixIterator{*it, nil}, []byte(to)}}
+	case from != "" && prefix+to == "":
+		return &badgerFromIterator{badgerPrefixIterator{*it, []byte(from)}}
+	case from != "" && to != "" && prefix == "":
+		return &badgerFromToIterator{badgerPrefixIterator{*it, []byte(from)}, []byte(to)}
+	case from == "":
+		lastInPrefix := lastInPrefix(prefix, to)
+		if keyLtEq(lastInPrefix, []byte(to)) {
+			return &badgerPrefixIterator{*it, []byte(prefix)}
 		}
-		if to != "" && prefix > to {
-			t = to
+		return &badgerFromToIterator{badgerPrefixIterator{*it, []byte(prefix)}, []byte(to)}
+	case to == "":
+		if prefix > from {
+			return &badgerPrefixIterator{*it, []byte(prefix)}
 		}
-		if f == t {
-			return &badgerPrefixIterator{*it, []byte(f)}
+		return &badgerPrefixFromIterator{badgerPrefixIterator{*it, []byte(prefix)}, []byte(from)}
+
+	default: // to != "" && prefix != "" && from != "":
+		f, t := from, to
+		if prefix > from {
+			f = prefix
 		}
-		return &badgerFromToIterator{
-			badgerPrefixIterator: badgerPrefixIterator{*it, []byte(f)},
-			to:                   []byte(t),
+		lastInPrefix := lastInPrefix(prefix, to)
+		if keyLtEq(lastInPrefix, []byte(to)) {
+			if f == prefix {
+				return &badgerPrefixIterator{*it, []byte(prefix)}
+			}
+			return &badgerPrefixFromIterator{badgerPrefixIterator{*it, []byte(prefix)}, []byte(f)}
 		}
+		return &badgerFromToIterator{badgerPrefixIterator{*it, []byte(f)}, []byte(t)}
 	}
-	return it
+}
+
+func lastInPrefix(prefix, to string) []byte {
+	lastValueInPrefix := []byte(prefix)
+	if len(to)-len(prefix) > 0 {
+		padding := make([]byte, len(to)-len(prefix))
+		for i := range padding {
+			padding[i] = uint8(255)
+		}
+		lastValueInPrefix = append(lastValueInPrefix, padding...)
+	}
+	return lastValueInPrefix
 }
 
 func keyRangeIterator(it *badger.Iterator, keyRange *proto.KeyRange) Iterator {

--- a/impl/iterator_test.go
+++ b/impl/iterator_test.go
@@ -1,0 +1,92 @@
+package impl
+
+import (
+	"github.com/dgraph-io/badger/v3"
+	"reflect"
+	"testing"
+)
+
+func TestKeyRangeIterator(t *testing.T) {
+	aBadger := NewServer("", true)
+	anIterator := aBadger.NewTransaction(false).NewIterator(badger.DefaultIteratorOptions)
+	type args struct {
+		prefix string
+		from   string
+		to     string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Iterator
+	}{
+		{
+			name: "none-returns the wrapping iterator",
+			want: anIterator,
+			args: args{},
+		}, {
+			name: "prefix returns a prefix iterator",
+			want: &badgerPrefixIterator{*anIterator, []byte("prefix")},
+			args: args{prefix: "prefix"},
+		}, {
+			name: "from-to returns a from-to iterator",
+			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("from")}, []byte("to")},
+			args: args{from: "from", to: "to"},
+		}, {
+			name: "from returns a from iterator",
+			want: &badgerFromIterator{badgerPrefixIterator{*anIterator, []byte("from")}},
+			args: args{from: "from"},
+		}, {
+			name: "to returns a to iterator",
+			want: &badgerToIterator{badgerFromToIterator{badgerPrefixIterator{*anIterator, nil}, []byte("to")}},
+			args: args{to: "to"},
+		}, {
+			name: "to-prefix returns a FromTo iterator",
+			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("d")}, []byte("dg")},
+			args: args{to: "dg", prefix: "d"},
+		}, {
+			name: "to-prefix returns a FromTo iterator, which is invalid",
+			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("d")}, []byte("c")},
+			args: args{to: "c", prefix: "d"},
+		}, {
+			name: "to-prefix returns a Prefix iterator",
+			want: &badgerPrefixIterator{*anIterator, []byte("g")},
+			args: args{to: "z", prefix: "g"},
+		}, {
+			name: "from-prefix returns a FromTo iterator",
+			want: &badgerPrefixFromIterator{badgerPrefixIterator{*anIterator, []byte("d")}, []byte("dg")},
+			args: args{from: "dg", prefix: "d"},
+		}, {
+			name: "from-prefix returns a Prefix iterator",
+			want: &badgerPrefixIterator{*anIterator, []byte("i")},
+			args: args{from: "g", prefix: "i"},
+		}, {
+			name: "from-prefix returns a PrefixFrom iterator, which will be invalid",
+			want: &badgerPrefixFromIterator{badgerPrefixIterator{*anIterator, []byte("i")}, []byte("k")},
+			args: args{from: "k", prefix: "i"},
+		}, {
+			name: "from-to-prefix returns a FromTo Iterator",
+			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("ka")}, []byte("kb")},
+			args: args{from: "ka", to: "kb", prefix: "k"},
+		}, {
+			name: "from-to-prefix returns a FromTo Iterator a out of bounds",
+			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("k")}, []byte("kb")},
+			args: args{from: "a", to: "kb", prefix: "k"},
+		}, {
+			name: "from-to-prefix returns a Prefix Iterator",
+			want: &badgerPrefixIterator{*anIterator, []byte("b")},
+			args: args{from: "a", to: "c", prefix: "b"},
+		}, {
+			name: "from-to-prefix returns a PrefixFrom Iterator",
+			want: &badgerPrefixFromIterator{badgerPrefixIterator{*anIterator, []byte("b")}, []byte("bb")},
+			args: args{from: "bb", to: "c", prefix: "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := KeyRangeIterator(anIterator, tt.args.prefix, tt.args.from, tt.args.to)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("KeyRangeIterator() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/impl/iterator_test.go
+++ b/impl/iterator_test.go
@@ -25,59 +25,59 @@ func TestKeyRangeIterator(t *testing.T) {
 			args: args{},
 		}, {
 			name: "prefix returns a prefix iterator",
-			want: &badgerPrefixIterator{*anIterator, []byte("prefix")},
+			want: &badgerPrefixIterator{anIterator, []byte("prefix")},
 			args: args{prefix: "prefix"},
 		}, {
 			name: "from-to returns a from-to iterator",
-			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("from")}, []byte("to")},
+			want: &badgerFromToIterator{&badgerPrefixIterator{anIterator, []byte("from")}, []byte("to")},
 			args: args{from: "from", to: "to"},
 		}, {
 			name: "from returns a from iterator",
-			want: &badgerFromIterator{badgerPrefixIterator{*anIterator, []byte("from")}},
+			want: &badgerFromIterator{&badgerPrefixIterator{anIterator, []byte("from")}},
 			args: args{from: "from"},
 		}, {
 			name: "to returns a to iterator",
-			want: &badgerToIterator{badgerFromToIterator{badgerPrefixIterator{*anIterator, nil}, []byte("to")}},
+			want: &badgerToIterator{&badgerFromToIterator{&badgerPrefixIterator{anIterator, nil}, []byte("to")}},
 			args: args{to: "to"},
 		}, {
 			name: "to-prefix returns a FromTo iterator",
-			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("d")}, []byte("dg")},
+			want: &badgerFromToIterator{&badgerPrefixIterator{anIterator, []byte("d")}, []byte("dg")},
 			args: args{to: "dg", prefix: "d"},
 		}, {
 			name: "to-prefix returns a FromTo iterator, which is invalid",
-			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("d")}, []byte("c")},
+			want: &badgerFromToIterator{&badgerPrefixIterator{anIterator, []byte("d")}, []byte("c")},
 			args: args{to: "c", prefix: "d"},
 		}, {
 			name: "to-prefix returns a Prefix iterator",
-			want: &badgerPrefixIterator{*anIterator, []byte("g")},
+			want: &badgerPrefixIterator{anIterator, []byte("g")},
 			args: args{to: "z", prefix: "g"},
 		}, {
 			name: "from-prefix returns a FromTo iterator",
-			want: &badgerPrefixFromIterator{badgerPrefixIterator{*anIterator, []byte("d")}, []byte("dg")},
+			want: &badgerPrefixFromIterator{&badgerPrefixIterator{anIterator, []byte("d")}, []byte("dg")},
 			args: args{from: "dg", prefix: "d"},
 		}, {
 			name: "from-prefix returns a Prefix iterator",
-			want: &badgerPrefixIterator{*anIterator, []byte("i")},
+			want: &badgerPrefixIterator{anIterator, []byte("i")},
 			args: args{from: "g", prefix: "i"},
 		}, {
 			name: "from-prefix returns a PrefixFrom iterator, which will be invalid",
-			want: &badgerPrefixFromIterator{badgerPrefixIterator{*anIterator, []byte("i")}, []byte("k")},
+			want: &badgerPrefixFromIterator{&badgerPrefixIterator{anIterator, []byte("i")}, []byte("k")},
 			args: args{from: "k", prefix: "i"},
 		}, {
 			name: "from-to-prefix returns a FromTo Iterator",
-			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("ka")}, []byte("kb")},
+			want: &badgerFromToIterator{&badgerPrefixIterator{anIterator, []byte("ka")}, []byte("kb")},
 			args: args{from: "ka", to: "kb", prefix: "k"},
 		}, {
 			name: "from-to-prefix returns a FromTo Iterator a out of bounds",
-			want: &badgerFromToIterator{badgerPrefixIterator{*anIterator, []byte("k")}, []byte("kb")},
+			want: &badgerFromToIterator{&badgerPrefixIterator{anIterator, []byte("k")}, []byte("kb")},
 			args: args{from: "a", to: "kb", prefix: "k"},
 		}, {
 			name: "from-to-prefix returns a Prefix Iterator",
-			want: &badgerPrefixIterator{*anIterator, []byte("b")},
+			want: &badgerPrefixIterator{anIterator, []byte("b")},
 			args: args{from: "a", to: "c", prefix: "b"},
 		}, {
 			name: "from-to-prefix returns a PrefixFrom Iterator",
-			want: &badgerPrefixFromIterator{badgerPrefixIterator{*anIterator, []byte("b")}, []byte("bb")},
+			want: &badgerPrefixFromIterator{&badgerPrefixIterator{anIterator, []byte("b")}, []byte("bb")},
 			args: args{from: "bb", to: "c", prefix: "b"},
 		},
 	}

--- a/impl/matcher_test.go
+++ b/impl/matcher_test.go
@@ -1,0 +1,16 @@
+package impl
+
+import (
+	"testing"
+)
+
+func TestNewMatcherEmptyString(t *testing.T) {
+	got, err := NewMatcher("")
+	if err != nil {
+		t.Errorf("NewMatcher() error = %v", err)
+		return
+	}
+	if !got.Match(nil) && !got.Match([]byte("any")) && !got.Match([]byte("是")) {
+		t.Errorf("Matcher doesn't match true always: %v", got)
+	}
+}

--- a/impl/service.go
+++ b/impl/service.go
@@ -16,6 +16,7 @@ type ldService struct {
 // that implements the proto interface proto.LdServer.
 func NewServer(dbLocation string, inmem bool) *ldService {
 	if inmem {
+		log.Infof("overwriting db-location: %s, because instance is set to run in-memory", dbLocation)
 		dbLocation = ""
 	}
 	db, err := badger.Open(badger.DefaultOptions(dbLocation).WithInMemory(inmem))

--- a/impl/service.go
+++ b/impl/service.go
@@ -16,7 +16,7 @@ type ldService struct {
 // that implements the proto interface proto.LdServer.
 func NewServer(dbLocation string, inmem bool) *ldService {
 	if inmem {
-		log.Infof("overwriting db-location: %s, because instance is set to run in-memory", dbLocation)
+		log.Infof("ignoring db-location: %s, because instance is set to run in-memory", dbLocation)
 		dbLocation = ""
 	}
 	db, err := badger.Open(badger.DefaultOptions(dbLocation).WithInMemory(inmem))

--- a/impl/service.go
+++ b/impl/service.go
@@ -2,10 +2,10 @@ package impl
 
 import (
 	pb "github.com/MikkelHJuul/ld/proto"
-	"log"
-	"sync"
-
 	"github.com/dgraph-io/badger/v3"
+	log "github.com/sirupsen/logrus"
+
+	"sync"
 )
 
 type ldService struct {
@@ -15,6 +15,9 @@ type ldService struct {
 // NewServer opens and returns a badger.DB facade
 // that implements the proto interface proto.LdServer.
 func NewServer(dbLocation string, inmem bool) *ldService {
+	if inmem {
+		dbLocation = ""
+	}
 	db, err := badger.Open(badger.DefaultOptions(dbLocation).WithInMemory(inmem))
 	if err != nil {
 		log.Fatal(err)
@@ -28,10 +31,10 @@ func (l ldService) sendKeyWith(out chan *pb.KeyValue, txn *badger.Txn, wg *sync.
 	if err == badger.ErrTxnTooBig {
 		err = txn.Commit()
 		if err != nil {
-			log.Print(err) //uncommitted read-transaction... hope it is fine
+			log.Warn(err) //uncommitted read-transaction... hope it is fine
 		}
 		if err = sendKeyValue(out, txn, key); err != nil {
-			log.Print("could not finish transaction after failure")
+			log.Error("could not finish transaction after failure")
 		}
 	}
 }
@@ -39,10 +42,18 @@ func (l ldService) sendKeyWith(out chan *pb.KeyValue, txn *badger.Txn, wg *sync.
 func sendKeyValue(out chan *pb.KeyValue, txn *badger.Txn, key *pb.Key) error {
 	var value []byte
 	value, err := readSingleFromKey(txn, key)
-	if err == badger.ErrKeyNotFound {
-		out <- &pb.KeyValue{}
-		err = nil
-	}
-	out <- &pb.KeyValue{Key: key.Key, Value: value}
+	kv, err := decideOutcome(err, key.Key, value)
+	out <- kv
 	return err
+}
+
+func decideOutcome(err error, key string, value []byte) (*pb.KeyValue, error) {
+	if err != nil {
+		if err == badger.ErrKeyNotFound {
+			return nil, nil
+		}
+		log.Warn("error in transaction", err)
+		return nil, err
+	}
+	return &pb.KeyValue{Key: key, Value: value}, nil
 }

--- a/impl/service_test.go
+++ b/impl/service_test.go
@@ -1,0 +1,24 @@
+package impl
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestInMemoryWorks(t *testing.T) {
+	NewServer("any", true)
+	_, err := ioutil.ReadDir("any")
+	if _, ok := err.(*os.PathError); !ok {
+		t.Error("got an unexpected error, or nil error when it should have been os.PathError", err)
+	}
+}
+
+func TestCreatesAFile(t *testing.T) {
+	NewServer("any", false)
+	defer os.RemoveAll("any")
+	_, err := ioutil.ReadDir("any")
+	if err != nil {
+		t.Error("got an error unexpectedly", err)
+	}
+}

--- a/impl/set_test.go
+++ b/impl/set_test.go
@@ -1,0 +1,51 @@
+package impl
+
+import (
+	"github.com/MikkelHJuul/ld/proto"
+	"testing"
+)
+
+func Test_ldService_SetMany(t *testing.T) {
+	tests := []struct {
+		name   string
+		server *testBidiServer
+	}{
+		{
+			name: "a simple server",
+			server: NewTestServer([]*proto.KeyValue{
+				{Key: "1", Value: []byte("1")},
+				{Key: "2", Value: []byte("2")},
+				{Key: "3", Value: []byte("3")},
+				{Key: "4", Value: []byte("4")},
+				{Key: "5", Value: []byte("5")},
+			}),
+		},
+		{
+			name: "a simple server re-set key",
+			server: NewTestServer([]*proto.KeyValue{
+				{Key: "1", Value: []byte("1")},
+				{Key: "1", Value: []byte("1")},
+				{Key: "1", Value: []byte("4")},
+				{Key: "1", Value: []byte("2")},
+				{Key: "1", Value: []byte("1")},
+				{Key: "1", Value: []byte("1")},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewServer("", true)
+			if err := l.SetMany(tt.server); err != nil {
+				t.Errorf("SetMany() error = %v", err)
+			}
+			if len(tt.server.send) != len(tt.server.receive) {
+				t.Errorf("mismatch in values received and sent")
+			}
+			for _, it := range tt.server.receive {
+				if it != nil {
+					t.Errorf("non-nil return")
+				}
+			}
+		})
+	}
+}

--- a/impl/set_test.go
+++ b/impl/set_test.go
@@ -12,7 +12,7 @@ func Test_ldService_SetMany(t *testing.T) {
 	}{
 		{
 			name: "a simple server",
-			server: NewTestServer([]*proto.KeyValue{
+			server: newTestServer([]*proto.KeyValue{
 				{Key: "1", Value: []byte("1")},
 				{Key: "2", Value: []byte("2")},
 				{Key: "3", Value: []byte("3")},
@@ -22,7 +22,7 @@ func Test_ldService_SetMany(t *testing.T) {
 		},
 		{
 			name: "a simple server re-set key",
-			server: NewTestServer([]*proto.KeyValue{
+			server: newTestServer([]*proto.KeyValue{
 				{Key: "1", Value: []byte("1")},
 				{Key: "1", Value: []byte("1")},
 				{Key: "1", Value: []byte("4")},

--- a/impl/simple_operations_test.go
+++ b/impl/simple_operations_test.go
@@ -1,0 +1,33 @@
+package impl
+
+import (
+    "testing"
+
+    pb "github.com/MikkelHJuul/ld/proto"
+)
+
+type resp struct {
+    KV  *pb.KeyValue
+    E   error
+}
+
+type kOp struct {
+    Key *pb.Key
+    Resp resp
+}
+
+type kvOp struct {
+    KV  *pb.KeyValue
+    Resp resp
+}
+
+type case struct {
+    Set []kvOp
+    Get []kOp
+    Del []kOp
+}
+
+func TestSetGetDeleteSingles(t *testing.T) {
+    ld := NewServer("tmp/ldsgdtest", false)
+    //cases := 
+}

--- a/impl/simple_operations_test.go
+++ b/impl/simple_operations_test.go
@@ -122,7 +122,7 @@ func TestSetGetDeleteSingles(t *testing.T) {
 	}
 	for _, aCase := range cases {
 		t.Run(aCase.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("tmp", "ldgsdtest")
+			dir, err := ioutil.TempDir("/tmp", "ldgsdtest")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/impl/simple_operations_test.go
+++ b/impl/simple_operations_test.go
@@ -1,33 +1,173 @@
 package impl
 
 import (
-    "testing"
+	"context"
+	"io/ioutil"
+	"reflect"
+	"testing"
 
-    pb "github.com/MikkelHJuul/ld/proto"
+	pb "github.com/MikkelHJuul/ld/proto"
 )
 
 type resp struct {
-    KV  *pb.KeyValue
-    E   error
+	KV *pb.KeyValue
+	E  error
 }
 
 type kOp struct {
-    Key *pb.Key
-    Resp resp
+	Key  *pb.Key
+	Resp resp
 }
 
 type kvOp struct {
-    KV  *pb.KeyValue
-    Resp resp
+	KV   *pb.KeyValue
+	Resp resp
 }
 
-type case struct {
-    Set []kvOp
-    Get []kOp
-    Del []kOp
+type aCase struct {
+	name      string
+	GetBefore []kOp
+	Set       []kvOp
+	Get       []kOp
+	Del       []kOp
+	GetAfter  []kOp
 }
 
 func TestSetGetDeleteSingles(t *testing.T) {
-    ld := NewServer("tmp/ldsgdtest", false)
-    //cases := 
+	lilly := &pb.KeyValue{Key: "hello", Value: []byte("Lilly")}
+	ellis := &pb.KeyValue{Key: "hi", Value: []byte("Ellis")}
+	cases := []aCase{
+		{
+			name: "test set, get and delete correct outcome",
+			GetBefore: []kOp{
+				{
+					Key:  &pb.Key{Key: "hello"},
+					Resp: resp{KV: nil},
+				},
+				{
+					Key:  &pb.Key{Key: "hi"},
+					Resp: resp{KV: nil},
+				},
+			},
+			Set: []kvOp{
+				{
+					KV:   lilly,
+					Resp: resp{},
+				},
+				{
+					KV:   ellis,
+					Resp: resp{},
+				},
+			},
+			Get: []kOp{
+				{
+					Key:  &pb.Key{Key: "hello"},
+					Resp: resp{KV: lilly},
+				},
+				{
+					Key:  &pb.Key{Key: "hi"},
+					Resp: resp{KV: ellis},
+				},
+				{ //assert twice
+					Key:  &pb.Key{Key: "hi"},
+					Resp: resp{KV: ellis},
+				},
+			},
+			Del: []kOp{
+				{
+					Key:  &pb.Key{Key: "hello"},
+					Resp: resp{KV: lilly},
+				},
+				{
+					Key:  &pb.Key{Key: "hi"},
+					Resp: resp{KV: ellis},
+				},
+				{ //assert second time it's gone
+					Key:  &pb.Key{Key: "hi"},
+					Resp: resp{KV: nil},
+				},
+			},
+			GetAfter: []kOp{
+				{
+					Key:  &pb.Key{Key: "hello"},
+					Resp: resp{KV: nil},
+				},
+				{
+					Key:  &pb.Key{Key: "hi"},
+					Resp: resp{KV: nil},
+				},
+			},
+		},
+		{
+			name: "ingest empty-value object",
+			Set: []kvOp{
+				{
+					KV:   &pb.KeyValue{Key: "empty"},
+					Resp: resp{},
+				},
+			},
+			Get: []kOp{
+				{
+					Key:  &pb.Key{Key: "empty"},
+					Resp: resp{KV: &pb.KeyValue{Key: "empty"}},
+				},
+			},
+			Del: []kOp{
+				{
+					Key:  &pb.Key{Key: "empty"},
+					Resp: resp{KV: &pb.KeyValue{Key: "empty"}},
+				},
+			},
+		},
+	}
+	for _, aCase := range cases {
+		t.Run(aCase.name, func(t *testing.T) {
+			dir, err := ioutil.TempDir("tmp", "ldgsdtest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ld := NewServer(dir, false)
+			ctx := context.Background()
+			for _, op := range aCase.GetBefore {
+				checkReturn(t, "GetBefore",
+					func() (*pb.KeyValue, error) {
+						return ld.Get(ctx, op.Key)
+					}, op.Resp.KV)
+			}
+			for _, op := range aCase.Set {
+				checkReturn(t, "Set",
+					func() (*pb.KeyValue, error) {
+						return ld.Set(ctx, op.KV)
+					}, op.Resp.KV)
+			}
+			for _, op := range aCase.Get {
+				checkReturn(t, "Get",
+					func() (*pb.KeyValue, error) {
+						return ld.Get(ctx, op.Key)
+					}, op.Resp.KV)
+			}
+			for _, op := range aCase.Del {
+				checkReturn(t, "Del",
+					func() (*pb.KeyValue, error) {
+						return ld.Delete(ctx, op.Key)
+					}, op.Resp.KV)
+			}
+			for _, op := range aCase.GetAfter {
+				checkReturn(t, "GetAfter",
+					func() (*pb.KeyValue, error) {
+						return ld.Get(ctx, op.Key)
+					}, op.Resp.KV)
+			}
+		})
+	}
+}
+
+func checkReturn(t *testing.T, name string, methd func() (*pb.KeyValue, error), equalsObj *pb.KeyValue) {
+	kv, err := methd()
+	if err != nil {
+		t.Errorf("unexpected error in %s: %v", name, err)
+	}
+	if !reflect.DeepEqual(kv, equalsObj) {
+		t.Errorf("response in %s returned unexpected response: %v", name, kv)
+	}
 }

--- a/impl/stuff_for_test.go
+++ b/impl/stuff_for_test.go
@@ -1,0 +1,75 @@
+package impl
+
+import (
+	"fmt"
+	"github.com/MikkelHJuul/ld/proto"
+	"google.golang.org/grpc"
+	"io"
+)
+
+type testBidiServer struct {
+	grpc.ServerStream
+	send    []*proto.KeyValue
+	receive []*proto.KeyValue
+	idx     int
+}
+
+type testBidiKeyServer struct {
+	testBidiServer
+	send []*proto.Key
+}
+
+func NewTestKeyServer(ks []*proto.Key) *testBidiKeyServer {
+	return &testBidiKeyServer{
+		send: ks,
+		testBidiServer: testBidiServer{
+			receive: make([]*proto.KeyValue, 0),
+			idx:     0,
+		},
+	}
+}
+
+func NewTestServer(kvs []*proto.KeyValue) *testBidiServer {
+	return &testBidiServer{
+		send:    kvs,
+		receive: make([]*proto.KeyValue, 0),
+		idx:     0,
+	}
+}
+
+func (s *testBidiKeyServer) Recv() (*proto.Key, error) {
+	if len(s.send) == s.idx {
+		return nil, io.EOF
+	}
+	val := s.send[s.idx]
+	s.idx++
+	return val, nil
+}
+
+func (s *testBidiServer) Recv() (*proto.KeyValue, error) {
+	if len(s.send) == s.idx {
+		return nil, io.EOF
+	}
+	val := s.send[s.idx]
+	s.idx++
+	return val, nil
+}
+
+func (s *testBidiServer) Send(kv *proto.KeyValue) error {
+	s.receive = append(s.receive, kv)
+	return nil
+}
+
+func (s *testBidiKeyServer) Send(kv *proto.KeyValue) error {
+	s.receive = append(s.receive, kv)
+	return nil
+}
+
+func oneThroughHundred() []*proto.KeyValue {
+	lst := make([]*proto.KeyValue, 100)
+	for i := 0; i < 100; i++ {
+		k := fmt.Sprintf("%02d", i)
+		lst[i] = &proto.KeyValue{Key: k, Value: []byte(k)}
+	}
+	return lst
+}

--- a/impl/stuff_for_test.go
+++ b/impl/stuff_for_test.go
@@ -17,21 +17,21 @@ type testBidiServer struct {
 }
 
 type testBidiKeyServer struct {
-	testBidiServer
-	send []*proto.Key
+	grpc.ServerStream
+	send    []*proto.Key
+	receive []*proto.KeyValue
+	idx     int
 }
 
-func NewTestKeyServer(ks []*proto.Key) *testBidiKeyServer {
+func newTestKeyServer(ks []*proto.Key) *testBidiKeyServer {
 	return &testBidiKeyServer{
-		send: ks,
-		testBidiServer: testBidiServer{
-			receive: make([]*proto.KeyValue, 0),
-			idx:     0,
-		},
+		send:    ks,
+		receive: make([]*proto.KeyValue, 0),
+		idx:     0,
 	}
 }
 
-func NewTestServer(kvs []*proto.KeyValue) *testBidiServer {
+func newTestServer(kvs []*proto.KeyValue) *testBidiServer {
 	return &testBidiServer{
 		send:    kvs,
 		receive: make([]*proto.KeyValue, 0),
@@ -76,9 +76,9 @@ func oneThroughHundred() []*proto.KeyValue {
 	return lst
 }
 
-func NewTestBadger(t *testing.T) *ldService {
+func newTestBadger(t *testing.T) *ldService {
 	l := NewServer("", true)
-	err := l.SetMany(NewTestServer(oneThroughHundred()))
+	err := l.SetMany(newTestServer(oneThroughHundred()))
 	if err != nil {
 		t.Error("could not initiate test database")
 	}

--- a/impl/transaction.go
+++ b/impl/transaction.go
@@ -11,16 +11,13 @@ func readSingleFromKey(txn *badger.Txn, key *proto.Key) (value []byte, err error
 
 func readSingle(txn *badger.Txn, key []byte) (value []byte, err error) {
 	value = nil
-	if item, err := readSingleItem(txn, key); err == nil {
+	item, err := readSingleItem(txn, key)
+	if err == nil {
 		return item.ValueCopy(nil)
 	}
 	return
 }
 
 func readSingleItem(txn *badger.Txn, key []byte) (*badger.Item, error) {
-	item, err := txn.Get(key)
-	if err != nil {
-		return nil, err
-	}
-	return item, nil
+	return txn.Get(key)
 }

--- a/main.go
+++ b/main.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	port     = flag.String("port", lookupEnvOrString("PORT", "5326"), "The server port, default 5326")
-	logLevel = flag.String("log-level", lookupEnvOrString("LOG_LEVEL", "INFO"), "configure logging level")
-	mem      = flag.Bool("in-mem", func() bool { _, ok := os.LookupEnv("IN_MEM"); return ok }(), "if the database is in-memory")
+	port       = flag.String("port", lookupEnvOrString("PORT", "5326"), "The server port, default 5326")
+	dbLocation = flag.String("db-location", lookupEnvOrString("DB_LOCATION", "ld_badger"), "folder location where the database is situated")
+	logLevel   = flag.String("log-level", lookupEnvOrString("LOG_LEVEL", "INFO"), "configure logging level")
+	mem        = flag.Bool("in-mem", func() bool { _, ok := os.LookupEnv("IN_MEM"); return ok }(), "if the database is in-memory")
 )
 
 func lookupEnvOrString(key string, defaultVal string) string {
@@ -37,7 +38,7 @@ func main() {
 	}
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
-	server := impl.NewServer("ld_badger", *mem)
+	server := impl.NewServer(*dbLocation, *mem)
 	defer func() {
 		if err := server.Close(); err != nil {
 			log.Error("error when closing the database", err)

--- a/test/ingest.go
+++ b/test/ingest.go
@@ -23,7 +23,11 @@ func main() {
 	client := ld_proto.NewLdClient(conn)
 	ctx := context.TODO()
 
-	stream, _ := client.SetMany(ctx)
+	stream, err := client.SetMany(ctx)
+
+	if err != nil {
+		log.Fatal("fail", err)
+	}
 
 	go func() {
 		jsonFile, err := os.Open("all.txt")


### PR DESCRIPTION
Changes:
- bugfix: send nil, not empty KeyValue, on NoKeyError
- bugfix: in-mem flag could not be used, badger panics on passing a location and inmem
- rework of iterator.go, 
   - no api-changes, some bugfixes, some branches of the logic tree lacked implementation, see impl/iterator.go/impl/iterator_test.go
- added feature to set the database's folder-location
- added 53 tests/900 lines

known bugs:
- no released image, the docker image doesn't seem to work; something like this error: https://stackoverflow.com/questions/60921993/docker-and-grpc-connection-closed